### PR TITLE
Remove styling from button

### DIFF
--- a/src/components/StandardUI.js
+++ b/src/components/StandardUI.js
@@ -189,7 +189,7 @@ const StandardUI = () => {
             {error && <p className="text-red-500 text-sm">{error}</p>}
             <Button
               onClick={handleVerify}
-              className="w-full text-slate-50 hover:bg-slate-900"
+              className="w-full text-slate-50"
               disabled={loading}
             >
               {loading ? 'Verifying...' : 'Verify'}


### PR DESCRIPTION
The "Verify" button was being styled by `StandardUI.js` and `button.js`. I removed the styling from `StandardUI.js`